### PR TITLE
Add message destination and node cookie parameters

### DIFF
--- a/src/erlang.zig
+++ b/src/erlang.zig
@@ -74,7 +74,7 @@ pub const Node = struct {
         } else {
             const destination_name: [*:0]u8 = @constCast(destination);
             try validate(
-                error.reg_send_failed_to_master,
+                error.reg_send_failed,
                 ei.ei_reg_send(&ec.c_node, ec.fd, destination_name, buf.buff, buf.index),
             );
         }

--- a/src/erlang.zig
+++ b/src/erlang.zig
@@ -22,9 +22,8 @@ pub const Node = struct {
     c_node: ei.ei_cnode,
     fd: i32,
     node_name: [name_length:0]u8,
-    cookie: [:0]const u8 = "cookie",
 
-    pub fn init() !Node {
+    pub fn init(cookie: [:0]const u8) !Node {
         var tempNode: Node = .{
             .c_node = undefined,
             .fd = undefined,
@@ -41,7 +40,7 @@ pub const Node = struct {
         const check = ei.ei_connect_init(
             &tempNode.c_node,
             &tempNode.node_name,
-            tempNode.cookie.ptr,
+            cookie.ptr,
             @truncate(creation_u),
         );
         try validate(error.ei_connect_init_failed, check);

--- a/src/erlang.zig
+++ b/src/erlang.zig
@@ -6,10 +6,6 @@ const std = @import("std");
 pub const receiver = @import("receiver.zig");
 pub const sender = @import("sender.zig");
 
-// TODO: move these elsewhere, maybe make them into parameters
-pub const process_name = "server";
-pub const server_name = process_name ++ "@localhost";
-
 pub const Send_Error = sender.Error || error{
     // TODO: rid the world of these terrible names
     new_with_version,
@@ -93,7 +89,7 @@ pub fn validate(error_tag: anytype, result_value: c_int) !void {
     }
 }
 
-pub fn establish_connection(ec: *Node, ip: []const u8) !void {
+pub fn establish_connection(ec: *Node, process_name: []const u8, ip: []const u8) !void {
     var buffer: [Node.max_buffer_size:0]u8 = .{0} ** Node.max_buffer_size;
     std.mem.copyForwards(u8, &buffer, process_name);
     buffer[process_name.len] = '@';

--- a/src/erlang.zig
+++ b/src/erlang.zig
@@ -64,12 +64,12 @@ pub const Node = struct {
         if (Destination == ei.erlang_pid) {
             try validate(
                 error.reg_send_failed,
-                ei.ei_send(ec.fd, &destination, buf.buff, buf.index),
+                ei.ei_send(ec.fd, @constCast(&destination), buf.buff, buf.index),
             );
         } else if (Destination == *ei.erlang_pid or Destination == *const ei.erlang_pid) {
             try validate(
                 error.reg_send_failed,
-                ei.ei_send(ec.fd, destination, buf.buff, buf.index),
+                ei.ei_send(ec.fd, @constCast(destination), buf.buff, buf.index),
             );
         } else {
             const destination_name: [*:0]u8 = @constCast(destination);


### PR DESCRIPTION
Allow clients to choose the cookie when creating a node, as well as choose the destination BEAM process when sending messages.