### PR TITLE
Update to Zig 0.14.0

### DIFF
--- a/README.org
+++ b/README.org
@@ -8,7 +8,7 @@
 
 This is a library for communicating with the BEAM from Zig. It is a wrapper
 around ~erl_interface~, which is provided with Erlang, and currently targets Zig version
-~0.13.0~.
+~0.14.0~.
 
 Note that ~erl_interface~ is not currently packaged for Zig, so users of Zerl will need
 to provide the dependency themselves.
@@ -21,7 +21,10 @@ between Zig and Erlang.
 *** 0.1 [1/1]
 - [X] Add unit tests for the decoder and encoder.
 
-*** 0.2 [0/1]
+*** 0.2 [1/1]
+- [X] Update to Zig 0.14.0.
+
+*** 0.3 [0/1]
 - [ ] Allow parsing tagged tuples with multiple items from Erlang into Zig tagged unions.
 
 *** Before 1.0 [0/3]

--- a/build.zig
+++ b/build.zig
@@ -55,7 +55,7 @@ pub fn build(b: *std.Build) !void {
         .link_libc = true,
     });
 
-    const ei_options = .{
+    const ei_options: std.Build.Module.LinkSystemLibraryOptions = .{
         .needed = true,
         .preferred_link_mode = .static,
     };

--- a/build.zig
+++ b/build.zig
@@ -63,9 +63,11 @@ pub fn build(b: *std.Build) !void {
     zerl.linkSystemLibrary("ei", ei_options);
 
     const lib_unit_tests = b.addTest(.{
-        .root_source_file = root_file,
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = root_file,
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     lib_unit_tests.linkLibC();
     lib_unit_tests.linkSystemLibrary2("ei", ei_options);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,8 +1,9 @@
 .{
-    .name = "zerl",
+    .name = .zerl,
+    .fingerprint = 0x32d7a028f67a67f7,
     .version = "0.1.0",
 
-    .minimum_zig_version = "0.13.0",
+    .minimum_zig_version = "0.14.0",
 
     .dependencies = .{
         // Technically, we depend on erl_interface from Erlang/OTP.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .zerl,
     .fingerprint = 0x32d7a028f67a67f7,
-    .version = "0.1.0",
+    .version = "0.2.0",
 
     .minimum_zig_version = "0.14.0",
 

--- a/examples/cards/build.zig
+++ b/examples/cards/build.zig
@@ -4,13 +4,15 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    const root_module = b.createModule(.{
+        .root_source_file = b.path("cards.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
     const client = b.addExecutable(.{
         .name = "cards",
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("cards.zig"),
-            .target = target,
-            .optimize = optimize,
-        }),
+        .root_module = root_module,
     });
     b.installArtifact(client);
 
@@ -18,7 +20,7 @@ pub fn build(b: *std.Build) !void {
         .target = target,
         .optimize = optimize,
     })) |zerl| {
-        client.root_module.addImport("zerl", zerl.module("zerl"));
+        root_module.addImport("zerl", zerl.module("zerl"));
     }
 
     if (b.lazyImport(@This(), "zerl")) |zerl_build| {

--- a/examples/cards/build.zig
+++ b/examples/cards/build.zig
@@ -6,9 +6,11 @@ pub fn build(b: *std.Build) !void {
 
     const client = b.addExecutable(.{
         .name = "cards",
-        .root_source_file = b.path("cards.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("cards.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     b.installArtifact(client);
 

--- a/examples/cards/build.zig.zon
+++ b/examples/cards/build.zig.zon
@@ -1,7 +1,8 @@
 .{
-    .name = "zerl-cards-example",
+    .name = .zerl_cards_example,
+    .fingerprint = 0xdd0ba34acf936d5b,
     .version = "0.0.0",
-    .minimum_zig_version = "0.13.0",
+    .minimum_zig_version = "0.14.0",
     .dependencies = .{
         .zerl = .{
             .path = "../../",

--- a/examples/cards/cards.zig
+++ b/examples/cards/cards.zig
@@ -24,9 +24,8 @@ const Value = enum {
     ace,
 };
 
-const Card_Tag = enum { card };
 const Card = struct {
-    Card_Tag,
+    enum { card },
     Value,
     Suit,
 };
@@ -39,8 +38,6 @@ const Message = union(enum) {
     shuffle: []const Card,
     bye: void,
 };
-
-const Message_Tag = @typeInfo(Message).@"union".tag_type.?;
 
 const Dealer_Error = enum {
     unknown_message,

--- a/examples/cards/cards.zig
+++ b/examples/cards/cards.zig
@@ -57,20 +57,19 @@ const Reply = union(enum) {
 };
 
 const deck: [52]Card = blk: {
-    // This just builds an array containing one of each card
-    var cards: [52]Card = undefined;
+    var cards: [4][13]Card = undefined;
     for (std.enums.values(Suit)) |suit| {
         for (std.enums.values(Value)) |value| {
-            cards[
-                @as(usize, @intFromEnum(suit)) * 13 + @intFromEnum(value)
-            ] = .{
+            cards[@intFromEnum(suit)][@intFromEnum(value)] = .{
                 .card,
                 value,
                 suit,
             };
         }
     }
-    break :blk cards;
+    // workaround for https://github.com/ziglang/zig/issues/23673
+    const ret: *[52]Card = @ptrCast(&cards);
+    break :blk ret.*;
 };
 
 pub fn main() !void {

--- a/examples/cards/cards.zig
+++ b/examples/cards/cards.zig
@@ -40,7 +40,7 @@ const Message = union(enum) {
     bye: void,
 };
 
-const Message_Tag = @typeInfo(Message).Union.tag_type.?;
+const Message_Tag = @typeInfo(Message).@"union".tag_type.?;
 
 const Dealer_Error = enum {
     unknown_message,
@@ -59,9 +59,9 @@ const Reply = union(enum) {
 const deck: [52]Card = blk: {
     // This just builds an array containing one of each card
     var cards: [4][13]Card = undefined;
-    for (@typeInfo(Suit).Enum.fields, 0..) |suit_field, suit_index| {
+    for (@typeInfo(Suit).@"enum".fields, 0..) |suit_field, suit_index| {
         const suit: Suit = @enumFromInt(suit_field.value);
-        for (@typeInfo(Value).Enum.fields, 0..) |value, value_index| {
+        for (@typeInfo(Value).@"enum".fields, 0..) |value, value_index| {
             cards[suit_index][value_index] = .{ .card, @enumFromInt(value.value), suit };
         }
     }

--- a/examples/cards/cards.zig
+++ b/examples/cards/cards.zig
@@ -58,14 +58,19 @@ const Reply = union(enum) {
 
 const deck: [52]Card = blk: {
     // This just builds an array containing one of each card
-    var cards: [4][13]Card = undefined;
-    for (@typeInfo(Suit).@"enum".fields, 0..) |suit_field, suit_index| {
-        const suit: Suit = @enumFromInt(suit_field.value);
-        for (@typeInfo(Value).@"enum".fields, 0..) |value, value_index| {
-            cards[suit_index][value_index] = .{ .card, @enumFromInt(value.value), suit };
+    var cards: [52]Card = undefined;
+    for (std.enums.values(Suit)) |suit| {
+        for (std.enums.values(Value)) |value| {
+            cards[
+                @as(usize, @intFromEnum(suit)) * 13 + @intFromEnum(value)
+            ] = .{
+                .card,
+                value,
+                suit,
+            };
         }
     }
-    break :blk @bitCast(cards);
+    break :blk cards;
 };
 
 pub fn main() !void {

--- a/examples/hello/build.zig
+++ b/examples/hello/build.zig
@@ -6,9 +6,11 @@ pub fn build(b: *std.Build) !void {
 
     const client = b.addExecutable(.{
         .name = "hello",
-        .root_source_file = b.path("hello.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("hello.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     b.installArtifact(client);
 

--- a/examples/hello/build.zig
+++ b/examples/hello/build.zig
@@ -4,13 +4,15 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    const root_module = b.createModule(.{
+        .root_source_file = b.path("hello.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
     const client = b.addExecutable(.{
         .name = "hello",
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("hello.zig"),
-            .target = target,
-            .optimize = optimize,
-        }),
+        .root_module = root_module,
     });
     b.installArtifact(client);
 
@@ -18,7 +20,7 @@ pub fn build(b: *std.Build) !void {
         .target = target,
         .optimize = optimize,
     })) |zerl| {
-        client.root_module.addImport("zerl", zerl.module("zerl"));
+        root_module.addImport("zerl", zerl.module("zerl"));
     }
 
     if (b.lazyImport(@This(), "zerl")) |zerl_build| {

--- a/examples/hello/build.zig.zon
+++ b/examples/hello/build.zig.zon
@@ -1,7 +1,8 @@
 .{
-    .name = "zerl-hello-example",
+    .name = .zerl_hello_example,
+    .fingerprint = 0x9c6739caed6e6ae4,
     .version = "0.0.0",
-    .minimum_zig_version = "0.13.0",
+    .minimum_zig_version = "0.14.0",
     .dependencies = .{
         .zerl = .{
             .path = "../../",

--- a/flake.lock
+++ b/flake.lock
@@ -2,66 +2,28 @@
   "nodes": {
     "cachix": {
       "inputs": {
-        "devenv": "devenv_2",
+        "devenv": [
+          "devenv"
+        ],
         "flake-compat": [
-          "devenv",
-          "flake-compat"
+          "devenv"
         ],
         "git-hooks": [
-          "devenv",
-          "pre-commit-hooks"
+          "devenv"
         ],
-        "nixpkgs": [
-          "devenv",
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1726520618,
-        "narHash": "sha256-jOsaBmJ/EtX5t/vbylCdS7pWYcKGmWOKg4QKUzKr6dA=",
+        "lastModified": 1737621947,
+        "narHash": "sha256-8HFvG7fvIFbgtaYAY2628Tb89fA55nPm2jSiNs0/Cws=",
         "owner": "cachix",
         "repo": "cachix",
-        "rev": "695525f9086542dfb09fde0871dbf4174abbf634",
+        "rev": "f65a3cd5e339c223471e64c051434616e18cc4f5",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
-        "repo": "cachix",
-        "type": "github"
-      }
-    },
-    "cachix_2": {
-      "inputs": {
-        "devenv": "devenv_3",
-        "flake-compat": [
-          "devenv",
-          "cachix",
-          "devenv",
-          "flake-compat"
-        ],
-        "nixpkgs": [
-          "devenv",
-          "cachix",
-          "devenv",
-          "nixpkgs"
-        ],
-        "pre-commit-hooks": [
-          "devenv",
-          "cachix",
-          "devenv",
-          "pre-commit-hooks"
-        ]
-      },
-      "locked": {
-        "lastModified": 1712055811,
-        "narHash": "sha256-7FcfMm5A/f02yyzuavJe06zLa9hcMHsagE28ADcmQvk=",
-        "owner": "cachix",
-        "repo": "cachix",
-        "rev": "02e38da89851ec7fec3356a5c04bc8349cae0e30",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
+        "ref": "latest",
         "repo": "cachix",
         "type": "github"
       }
@@ -69,92 +31,23 @@
     "devenv": {
       "inputs": {
         "cachix": "cachix",
-        "flake-compat": "flake-compat_2",
-        "nix": "nix_3",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "pre-commit-hooks": "pre-commit-hooks_2"
-      },
-      "locked": {
-        "lastModified": 1730412360,
-        "narHash": "sha256-gPXX25FQL5nhBgIn4nChyJzdXEa+hEyzJ7kITVDsqVM=",
-        "owner": "cachix",
-        "repo": "devenv",
-        "rev": "45847cb1f14a6d8cfa86ea943703c54a8798ae7e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "devenv",
-        "type": "github"
-      }
-    },
-    "devenv_2": {
-      "inputs": {
-        "cachix": "cachix_2",
-        "flake-compat": [
-          "devenv",
-          "cachix",
-          "flake-compat"
-        ],
-        "nix": "nix_2",
-        "nixpkgs": [
-          "devenv",
-          "cachix",
-          "nixpkgs"
-        ],
-        "pre-commit-hooks": [
-          "devenv",
-          "cachix",
-          "git-hooks"
-        ]
-      },
-      "locked": {
-        "lastModified": 1723156315,
-        "narHash": "sha256-0JrfahRMJ37Rf1i0iOOn+8Z4CLvbcGNwa2ChOAVrp/8=",
-        "owner": "cachix",
-        "repo": "devenv",
-        "rev": "ff5eb4f2accbcda963af67f1a1159e3f6c7f5f91",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "devenv",
-        "type": "github"
-      }
-    },
-    "devenv_3": {
-      "inputs": {
-        "flake-compat": [
-          "devenv",
-          "cachix",
-          "devenv",
-          "cachix",
-          "flake-compat"
-        ],
+        "flake-compat": "flake-compat",
+        "git-hooks": "git-hooks",
         "nix": "nix",
-        "nixpkgs": "nixpkgs",
-        "poetry2nix": "poetry2nix",
-        "pre-commit-hooks": [
-          "devenv",
-          "cachix",
-          "devenv",
-          "cachix",
-          "pre-commit-hooks"
+        "nixpkgs": [
+          "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1708704632,
-        "narHash": "sha256-w+dOIW60FKMaHI1q5714CSibk99JfYxm0CzTinYWr+Q=",
+        "lastModified": 1741348424,
+        "narHash": "sha256-nPwbJpX8AxmzbgRd2m6KHIbyN1xavq1BaBdJzO/lkW0=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "2ee4450b0f4b95a1b90f2eb5ffea98b90e48c196",
+        "rev": "8f8c96bb1e0c6a59a97592328dc61b9fdbe7474b",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
-        "ref": "python-rewrite",
         "repo": "devenv",
         "type": "github"
       }
@@ -162,27 +55,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
         "type": "github"
       },
       "original": {
@@ -214,39 +91,6 @@
       }
     },
     "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1689068808,
-        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_3": {
       "locked": {
         "lastModified": 1652776076,
         "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
@@ -262,16 +106,16 @@
         "type": "github"
       }
     },
-    "flake-utils_4": {
+    "flake-utils_2": {
       "inputs": {
-        "systems": "systems_2"
+        "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -280,11 +124,36 @@
         "type": "github"
       }
     },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": [
+          "devenv"
+        ],
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1740849354,
+        "narHash": "sha256-oy33+t09FraucSZ2rZ6qnD1Y1c8azKKmQuCvF2ytUko=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "4a709a8ce9f8c08fa7ddb86761fe488ff7858a07",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
           "devenv",
-          "pre-commit-hooks",
+          "git-hooks",
           "nixpkgs"
         ]
       },
@@ -320,108 +189,28 @@
     },
     "nix": {
       "inputs": {
-        "flake-compat": "flake-compat",
-        "nixpkgs": [
-          "devenv",
-          "cachix",
-          "devenv",
-          "cachix",
-          "devenv",
-          "nixpkgs"
-        ],
-        "nixpkgs-regression": "nixpkgs-regression"
-      },
-      "locked": {
-        "lastModified": 1712911606,
-        "narHash": "sha256-BGvBhepCufsjcUkXnEEXhEVjwdJAwPglCC2+bInc794=",
-        "owner": "domenkozar",
-        "repo": "nix",
-        "rev": "b24a9318ea3f3600c1e24b4a00691ee912d4de12",
-        "type": "github"
-      },
-      "original": {
-        "owner": "domenkozar",
-        "ref": "devenv-2.21",
-        "repo": "nix",
-        "type": "github"
-      }
-    },
-    "nix-github-actions": {
-      "inputs": {
-        "nixpkgs": [
-          "devenv",
-          "cachix",
-          "devenv",
-          "cachix",
-          "devenv",
-          "poetry2nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1688870561,
-        "narHash": "sha256-4UYkifnPEw1nAzqqPOTL2MvWtm3sNGw1UTYTalkTcGY=",
-        "owner": "nix-community",
-        "repo": "nix-github-actions",
-        "rev": "165b1650b753316aa7f1787f3005a8d2da0f5301",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nix-github-actions",
-        "type": "github"
-      }
-    },
-    "nix_2": {
-      "inputs": {
         "flake-compat": [
-          "devenv",
-          "cachix",
-          "devenv",
-          "flake-compat"
-        ],
-        "nixpkgs": [
-          "devenv",
-          "cachix",
-          "devenv",
-          "nixpkgs"
-        ],
-        "nixpkgs-regression": "nixpkgs-regression_2"
-      },
-      "locked": {
-        "lastModified": 1712911606,
-        "narHash": "sha256-BGvBhepCufsjcUkXnEEXhEVjwdJAwPglCC2+bInc794=",
-        "owner": "domenkozar",
-        "repo": "nix",
-        "rev": "b24a9318ea3f3600c1e24b4a00691ee912d4de12",
-        "type": "github"
-      },
-      "original": {
-        "owner": "domenkozar",
-        "ref": "devenv-2.21",
-        "repo": "nix",
-        "type": "github"
-      }
-    },
-    "nix_3": {
-      "inputs": {
-        "flake-compat": [
-          "devenv",
-          "flake-compat"
+          "devenv"
         ],
         "flake-parts": "flake-parts",
         "libgit2": "libgit2",
         "nixpkgs": "nixpkgs_2",
-        "nixpkgs-23-11": "nixpkgs-23-11",
-        "nixpkgs-regression": "nixpkgs-regression_3",
-        "pre-commit-hooks": "pre-commit-hooks"
+        "nixpkgs-23-11": [
+          "devenv"
+        ],
+        "nixpkgs-regression": [
+          "devenv"
+        ],
+        "pre-commit-hooks": [
+          "devenv"
+        ]
       },
       "locked": {
-        "lastModified": 1727438425,
-        "narHash": "sha256-X8ES7I1cfNhR9oKp06F6ir4Np70WGZU5sfCOuNBEwMg=",
+        "lastModified": 1734114420,
+        "narHash": "sha256-n52PUzub5jZWc8nI/sR7UICOheU8rNA+YZ73YaHeCBg=",
         "owner": "domenkozar",
         "repo": "nix",
-        "rev": "f6c5ae4c1b2e411e6b1e6a8181cc84363d6a7546",
+        "rev": "bde6a1a0d1f2af86caa4d20d23eca019f3d57eee",
         "type": "github"
       },
       "original": {
@@ -433,96 +222,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1692808169,
-        "narHash": "sha256-x9Opq06rIiwdwGeK2Ykj69dNc2IvUH1fY55Wm7atwrE=",
+        "lastModified": 1733212471,
+        "narHash": "sha256-M1+uCoV5igihRfcUKrr1riygbe73/dzNnzPsmaLCmpo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9201b5ff357e781bf014d0330d18555695df7ba8",
+        "rev": "55d15ad12a74eb7d4646254e13638ad0c4128776",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-23-11": {
-      "locked": {
-        "lastModified": 1717159533,
-        "narHash": "sha256-oamiKNfr2MS6yH64rUn99mIZjc45nGJlj9eGth/3Xuw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
-        "type": "github"
-      }
-    },
-    "nixpkgs-regression": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      }
-    },
-    "nixpkgs-regression_2": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      }
-    },
-    "nixpkgs-regression_3": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      }
-    },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1720386169,
-        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -545,11 +254,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1730200266,
-        "narHash": "sha256-l253w0XMT8nWHGXuXqyiIC/bMvh1VRszGXgdpQlfhvU=",
+        "lastModified": 1741379970,
+        "narHash": "sha256-Wh7esNh7G24qYleLvgOSY/7HlDUzWaL/n4qzlBePpiw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "807e9154dcb16384b1b765ebe9cd2bba2ac287fd",
+        "rev": "36fd87baa9083f34f7f5027900b62ee6d09b1f2f",
         "type": "github"
       },
       "original": {
@@ -561,113 +270,23 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1730100061,
-        "narHash": "sha256-6JpwtWs+gEht/lKjr0/wwvq7c7ttMoZOfImJxgCYtxk=",
+        "lastModified": 1741337598,
+        "narHash": "sha256-dw3gBBVV6o38e5IReRLC3PZdoMql6hOhM9AMXZ5dc5E=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b6b90562f7698ae015471fc4ff5d45399cc6622a",
+        "rev": "cee01a7a06c7b3ac6bf0055dd08e10aed275e6ba",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "poetry2nix": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nix-github-actions": "nix-github-actions",
-        "nixpkgs": [
-          "devenv",
-          "cachix",
-          "devenv",
-          "cachix",
-          "devenv",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1692876271,
-        "narHash": "sha256-IXfZEkI0Mal5y1jr6IRWMqK8GW2/f28xJenZIPQqkY0=",
-        "owner": "nix-community",
-        "repo": "poetry2nix",
-        "rev": "d5006be9c2c2417dafb2e2e5034d83fabd207ee3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "poetry2nix",
-        "type": "github"
-      }
-    },
-    "pre-commit-hooks": {
-      "inputs": {
-        "flake-compat": [
-          "devenv",
-          "nix"
-        ],
-        "flake-utils": "flake-utils_2",
-        "gitignore": [
-          "devenv",
-          "nix"
-        ],
-        "nixpkgs": [
-          "devenv",
-          "nix",
-          "nixpkgs"
-        ],
-        "nixpkgs-stable": [
-          "devenv",
-          "nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1712897695,
-        "narHash": "sha256-nMirxrGteNAl9sWiOhoN5tIHyjBbVi5e2tgZUgZlK3Y=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "40e6053ecb65fcbf12863338a6dcefb3f55f1bf8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "type": "github"
-      }
-    },
-    "pre-commit-hooks_2": {
-      "inputs": {
-        "flake-compat": [
-          "devenv",
-          "flake-compat"
-        ],
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "devenv",
-          "nixpkgs"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable"
-      },
-      "locked": {
-        "lastModified": 1726745158,
-        "narHash": "sha256-D5AegvGoEjt4rkKedmxlSEmC+nNLMBPWFxvmYnVLhjk=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "4e743a6920eab45e8ba0fbe49dc459f1423a4b74",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
         "devenv": "devenv",
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs_3",
         "zig2nix": "zig2nix"
       }
@@ -687,32 +306,17 @@
         "type": "github"
       }
     },
-    "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "zig2nix": {
       "inputs": {
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1730425494,
-        "narHash": "sha256-YqWLp7+yb/nBTBSqGRwKEdhnqvZzjxLbipr4wYpbpSs=",
+        "lastModified": 1741338346,
+        "narHash": "sha256-Zz2WWS+xbNATOWBjwAnoXENMlZ2tmi2Hvq8VYyfhxY0=",
         "owner": "Cloudef",
         "repo": "zig2nix",
-        "rev": "fa2908400c9fdf8a3aa52c048c5832649cf373bf",
+        "rev": "71b677286c756731225825a89cdc50a4f7a23754",
         "type": "github"
       },
       "original": {

--- a/src/Decoder.zig
+++ b/src/Decoder.zig
@@ -231,17 +231,17 @@ fn parse_int(self: Decoder, comptime T: type) Error!T {
     comptime assert(@bitSizeOf(T) <= @bitSizeOf(c_longlong));
     const N, const error_tag, const decode =
         if (@typeInfo(T).int.signedness == .signed)
-        .{
-            c_longlong,
-            error.decoding_signed_integer,
-            ei.ei_decode_longlong,
-        }
-    else
-        .{
-            c_ulonglong,
-            error.decoding_unsigned_integer,
-            ei.ei_decode_ulonglong,
-        };
+            .{
+                c_longlong,
+                error.decoding_signed_integer,
+                ei.ei_decode_longlong,
+            }
+        else
+            .{
+                c_ulonglong,
+                error.decoding_unsigned_integer,
+                ei.ei_decode_ulonglong,
+            };
 
     var n: N = undefined;
     try erl.validate(error_tag, decode(self.buf.buff, self.index, &n));
@@ -474,7 +474,7 @@ test parse_union {
 fn parse_pointer(self: Decoder, comptime T: type) Error!T {
     const type_info = @typeInfo(T).pointer;
     // TODO: figure out a sensible way to handle non-slices
-    comptime assert(type_info.size == .@"slice");
+    comptime assert(type_info.size == .slice);
 
     var size: c_int = 0;
     try erl.validate(

--- a/src/Decoder.zig
+++ b/src/Decoder.zig
@@ -104,9 +104,7 @@ fn parse_tuple(self: Decoder, comptime T: type) Error!T {
 }
 
 test parse_tuple {
-    // We need the comptime field here in 0.13.0 because of a bug.
-    // Problem is fixed in zig master.
-    const Point = struct { comptime enum { point } = .point, i32, i32 };
+    const Point = struct { enum { point }, i32, i32 };
     const point: Point = .{ .point, 413, 612 };
 
     var buf: ei.ei_x_buff = undefined;

--- a/src/encoder.zig
+++ b/src/encoder.zig
@@ -23,7 +23,7 @@ fn write_pointer(buf: *ei.ei_x_buff, data: anytype) Error!void {
     const info = @typeInfo(Data).pointer;
     switch (info.size) {
         .many, .c => @compileError("unsupported pointer size"),
-        .@"slice" => {
+        .slice => {
             try erl.validate(
                 error.could_not_encode_list_head,
                 ei.ei_x_encode_list_header(buf, @bitCast(data.len)),

--- a/src/encoder.zig
+++ b/src/encoder.zig
@@ -22,8 +22,8 @@ fn write_pointer(buf: *ei.ei_x_buff, data: anytype) Error!void {
     const Data = @TypeOf(data);
     const info = @typeInfo(Data).pointer;
     switch (info.size) {
-        .Many, .C => @compileError("unsupported pointer size"),
-        .Slice => {
+        .many, .c => @compileError("unsupported pointer size"),
+        .@"slice" => {
             try erl.validate(
                 error.could_not_encode_list_head,
                 ei.ei_x_encode_list_header(buf, @bitCast(data.len)),
@@ -34,7 +34,7 @@ fn write_pointer(buf: *ei.ei_x_buff, data: anytype) Error!void {
                 ei.ei_x_encode_list_header(buf, 0),
             );
         },
-        .One => {
+        .one => {
             const Child = info.child;
             switch (@typeInfo(Child)) {
                 .bool,


### PR DESCRIPTION
Updates library to Zig 0.14.0. Bumps version number to 0.2.

Includes a workaround for https://github.com/ziglang/zig/issues/23673.