### PR TITLE
Improve union handling

### DIFF
--- a/README.org
+++ b/README.org
@@ -24,13 +24,16 @@ between Zig and Erlang.
 *** 0.2 [1/1]
 - [X] Update to Zig 0.14.0.
 
-*** 0.3 [0/1]
-- [ ] Allow parsing tagged tuples with multiple items from Erlang into Zig tagged unions.
+*** 0.3 [1/1]
+- [X] Allow parsing tagged tuples with multiple items from Erlang into Zig tagged unions.
 
 *** Before 1.0 [0/3]
 - [ ] Expose the timeout version of the networking functions from ~erl_interface~.
 - [ ] Remove all hidden allocations from the library.
 - [ ] Either package ~erl_interface~ and add it to ~build.zig.zon~, or drop the dependency entirely.
+
+*** The Dream [0/1]
+- [ ] Drop the erl_interface dependency.
 
 ** Examples
 

--- a/README.org
+++ b/README.org
@@ -32,9 +32,6 @@ between Zig and Erlang.
 - [ ] Remove all hidden allocations from the library.
 - [ ] Either package ~erl_interface~ and add it to ~build.zig.zon~, or drop the dependency entirely.
 
-*** The Dream [0/1]
-- [ ] Drop the erl_interface dependency.
-
 ** Examples
 
 See the [[./examples]] directory for some code examples. If you are looking for a

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .zerl,
     .fingerprint = 0x32d7a028f67a67f7,
-    .version = "0.2.0",
+    .version = "0.3.0",
 
     .minimum_zig_version = "0.14.0",
 

--- a/doc/types.org
+++ b/doc/types.org
@@ -62,17 +62,21 @@ interact with binaries.
 
 ** Enums
 
-Enums are mapped to atoms because they're used in similar ways.
+Enums are mapped to atoms because fulfill similar purposes.
 
 ** Tuples and Tagged Unions
 
-Currently, Zig tuples can receive arbitrary Erlang tuples, while tagged unions
-can only receive tuples of length 2. This is not very convenient when dealing
-with Erlang records (which desugar to tagged tuples), but we do have plans to
-improve this area.
+Zig tuples can map to arbitrary Erlang tuples.
 
-Note that tagged union members with a payload of ~void~ are mapped to atoms
-instead, because it is not idiomatic in Erlang to pass around Tuples of one item.
+Tagged unions have a different mapping depending on the payload type:
+
+- Union members with a tuple or array payload are mapped to tuples of length
+  N + 1, where N is the payload size. The contents are an atom for the union
+  tag followed by the array or tuple elements in order.
+- Union members with a payload of ~void~ are mapped to atoms, because it is
+  not idiomatic in Erlang to pass around single-element tuples.
+- All other members are mapped to tuples of length 2, where the first element
+  is an atom for the union tag and the second element is the payload.
 
 There are no plans to support Zig untagged unions.
 

--- a/examples/cards/cards.zig
+++ b/examples/cards/cards.zig
@@ -24,11 +24,7 @@ const Value = enum {
     ace,
 };
 
-const Card = struct {
-    enum { card },
-    Value,
-    Suit,
-};
+const Card = union(enum) { card: struct { Value, Suit } };
 
 const Message = union(enum) {
     hello: *const zerl.ei.erlang_pid,
@@ -37,6 +33,21 @@ const Message = union(enum) {
     double: f64,
     shuffle: []const Card,
     bye: void,
+
+    pub fn format(self: Message, writer: *std.Io.Writer) !void {
+        // Forcibly print slice contents.
+        // Otherwise, we wouldn't be able to tell what the cards actually are.
+        switch (self) {
+            .shuffle => |cards| {
+                try writer.print(".{{ .shuffle = .{{", .{});
+                for (cards) |card| {
+                    try writer.print("{}, ", .{card});
+                }
+                try writer.print("}} }}", .{});
+            },
+            else => try writer.print("{any}", .{self}),
+        }
+    }
 };
 
 const Dealer_Error = enum {
@@ -51,20 +62,33 @@ const Reply = union(enum) {
     shuffled: []Card,
     ok: void,
     @"error": Dealer_Error,
+
+    pub fn format(self: Reply, writer: *std.Io.Writer) !void {
+        // Forcibly print slice contents.
+        // Otherwise, we wouldn't be able to tell what the cards actually are.
+        switch (self) {
+            .shuffled => |cards| {
+                try writer.print(".{{ .shuffled = .{{ ", .{});
+                for (cards) |card| {
+                    try writer.print("{}, ", .{card});
+                }
+                try writer.print("}} }}", .{});
+            },
+            else => try writer.print("{any}", .{self}),
+        }
+    }
 };
 
 const deck: [52]Card = blk: {
     var cards: [4][13]Card = undefined;
     for (std.enums.values(Suit)) |suit| {
         for (std.enums.values(Value)) |value| {
-            cards[@intFromEnum(suit)][@intFromEnum(value)] = .{
-                .card,
+            cards[@intFromEnum(suit)][@intFromEnum(value)] = .{ .card = .{
                 value,
                 suit,
-            };
+            } };
         }
     }
-    // workaround for https://github.com/ziglang/zig/issues/23673
     const ret: *[52]Card = @ptrCast(&cards);
     break :blk ret.*;
 };
@@ -99,10 +123,10 @@ pub fn main() !void {
         .bye,
     };
     for (messages) |message| {
-        try stderr.print("\nMessage: {}\n", .{message});
+        try stderr.print("\nMessage: {f}\n", .{message});
         try node.send("dealer", message);
         const reply = try node.receive(Reply, arena);
-        try stderr.print("\nReply: {}\n", .{reply});
+        try stderr.print("\nReply: {f}\n", .{reply});
     }
     try stderr.flush();
 }

--- a/src/Decoder.zig
+++ b/src/Decoder.zig
@@ -401,6 +401,16 @@ fn MaybeEnum(
     });
 }
 
+pub inline fn union_case(comptime T: type) enum { array, tuple, other } {
+    return case: switch (@typeInfo(T)) {
+        .array => .array,
+        .@"struct" => |Struct| {
+            break :case if (Struct.is_tuple) .tuple else .other;
+        },
+        else => .other,
+    };
+}
+
 fn parse_union(self: Decoder, comptime T: type) Error!T {
     const Tag = @typeInfo(T).@"union".tag_type.?;
 
@@ -446,6 +456,8 @@ fn parse_union(self: Decoder, comptime T: type) Error!T {
             ),
         };
     };
+    const previous_index = self.index.*;
+    errdefer self.index.* = previous_index;
 
     var arity: c_int = 0;
     var type_tag: c_int = 0;
@@ -454,6 +466,7 @@ fn parse_union(self: Decoder, comptime T: type) Error!T {
         error.could_not_get_type,
         ei.ei_get_type(self.buf.buff, self.index, &type_tag, &_v),
     );
+
     switch (type_tag) {
         ei.ERL_ATOM_EXT => {
             if (Atom == void) return error.could_not_decode_enum;
@@ -475,10 +488,6 @@ fn parse_union(self: Decoder, comptime T: type) Error!T {
                 error.decoding_tuple,
                 ei.ei_decode_tuple_header(self.buf.buff, self.index, &arity),
             );
-            if (arity != 2) {
-                // TODO: https://github.com/dont-rely-on-nulls/zerl/issues/7
-                return error.wrong_arity_for_tuple;
-            }
             const tuple_tag: Tag = @enumFromInt(@intFromEnum(
                 try self.parse_enum(Tuple_Tag),
             ));
@@ -487,8 +496,36 @@ fn parse_union(self: Decoder, comptime T: type) Error!T {
                     const Payload = @FieldType(T, @tagName(tag));
                     if (Payload == void) unreachable;
 
-                    const tuple_value = try self.parse(Payload);
-                    return @unionInit(T, @tagName(tag), tuple_value);
+                    var payload: Payload = undefined;
+
+                    switch (union_case(Payload)) {
+                        .array => {
+                            if (arity != payload.len + 1) {
+                                return error.wrong_arity_for_tuple;
+                            }
+                            for (&payload) |*elem| {
+                                elem.* = try self.parse(@TypeOf(elem.*));
+                            }
+                        },
+                        .tuple => {
+                            const tuple_len =
+                                @typeInfo(Payload).@"struct".fields.len;
+
+                            if (arity != tuple_len + 1) {
+                                return error.wrong_arity_for_tuple;
+                            }
+                            inline for (&payload) |*elem| {
+                                elem.* = try self.parse(@TypeOf(elem.*));
+                            }
+                        },
+                        .other => {
+                            if (arity != 2) {
+                                return error.wrong_arity_for_tuple;
+                            }
+                            payload = try self.parse(Payload);
+                        },
+                    }
+                    return @unionInit(T, @tagName(tag), payload);
                 },
             }
         },
@@ -527,6 +564,45 @@ test parse_union {
         .allocator = testing.failing_allocator,
     };
 
+    try erl.encoder.write_any(&buf, .not_a_shape);
+    try testing.expectEqual(error.could_not_decode_enum, decoder.parse_union(Shape));
+    try erl.validate(error.skip_term, ei.ei_skip_term(buf.buff, &index));
+
+    try erl.encoder.write_any(&buf, catdog);
+    try testing.expectEqual(error.could_not_decode_enum, decoder.parse_union(Animal));
+    try erl.validate(error.skip_term, ei.ei_skip_term(buf.buff, &index));
+
+    const Point = union(enum) {
+        array: [2]i32,
+        tuple: struct { i32, i32 },
+    };
+
+    const array: Point = .{ .array = .{ 413, 612 } };
+    const tuple: Point = .{ .tuple = .{ 413, 612 } };
+
+    const Flat_Point = struct { enum { array, tuple }, i32, i32 };
+
+    const flat_array: Flat_Point = .{ .array, 413, 612 };
+    const flat_tuple: Flat_Point = .{ .tuple, 413, 612 };
+
+    try erl.encoder.write_any(&buf, array);
+    try testing.expectEqual(array, decoder.parse_union(Point));
+
+    try erl.encoder.write_any(&buf, tuple);
+    try testing.expectEqual(tuple, decoder.parse_union(Point));
+
+    try erl.encoder.write_any(&buf, flat_array);
+    try testing.expectEqual(array, decoder.parse_union(Point));
+
+    try erl.encoder.write_any(&buf, flat_tuple);
+    try testing.expectEqual(tuple, decoder.parse_union(Point));
+
+    try erl.encoder.write_any(&buf, array);
+    try testing.expectEqual(flat_array, decoder.parse_tuple(Flat_Point));
+
+    try erl.encoder.write_any(&buf, tuple);
+    try testing.expectEqual(flat_tuple, decoder.parse_tuple(Flat_Point));
+
     try erl.encoder.write_any(&buf, circle);
     try testing.expectEqual(circle, decoder.parse_union(Shape));
 
@@ -535,12 +611,6 @@ test parse_union {
 
     try erl.encoder.write_any(&buf, Shape.point);
     try testing.expectEqual(Shape.point, decoder.parse_union(Shape));
-
-    try erl.encoder.write_any(&buf, .not_a_shape);
-    try testing.expectEqual(error.could_not_decode_enum, decoder.parse_union(Shape));
-
-    try erl.encoder.write_any(&buf, catdog);
-    try testing.expectEqual(error.could_not_decode_enum, decoder.parse_union(Animal));
 }
 
 fn parse_pointer(self: Decoder, comptime T: type) Error!T {

--- a/src/Decoder.zig
+++ b/src/Decoder.zig
@@ -36,6 +36,7 @@ pub const Error = std.mem.Allocator.Error || error{
     decoding_list_in_array_2,
     decoding_boolean,
     invalid_pid,
+    not_a_union,
 };
 
 buf: *ei.ei_x_buff,
@@ -386,10 +387,65 @@ test parse_enum {
     try testing.expectEqual(Suit.spades, decoder.parse_enum(Suit));
 }
 
+fn MaybeEnum(
+    comptime max_value: comptime_int,
+    comptime fields: []const std.builtin.Type.EnumField,
+) type {
+    return if (fields.len == 0) void else @Type(.{
+        .@"enum" = .{
+            .tag_type = std.math.IntFittingRange(0, max_value),
+            .fields = fields,
+            .decls = &.{},
+            .is_exhaustive = true,
+        },
+    });
+}
+
 fn parse_union(self: Decoder, comptime T: type) Error!T {
     const Tag = @typeInfo(T).@"union".tag_type.?;
-    const fields = @typeInfo(T).@"union".fields;
-    comptime assert(fields.len != 0);
+
+    const Atom: type, const Tuple_Tag: type = comptime Tags: {
+        const fields = @typeInfo(T).@"union".fields;
+        assert(fields.len != 0);
+
+        const Field = std.builtin.Type.EnumField;
+
+        var void_fields: [fields.len]Field = undefined;
+        var void_field_count = 0;
+        var void_max_value = 0;
+
+        var non_void_fields: [fields.len]Field = undefined;
+        var non_void_field_count = 0;
+        var non_void_max_value = 0;
+
+        for (fields) |field| {
+            const value = @intFromEnum(@field(Tag, field.name));
+            const enum_field: Field = .{
+                .name = field.name,
+                .value = value,
+            };
+
+            if (field.type == void) {
+                void_max_value = @max(void_max_value, value);
+                void_fields[void_field_count] = enum_field;
+                void_field_count += 1;
+            } else {
+                non_void_max_value = @max(non_void_max_value, value);
+                non_void_fields[non_void_field_count] = enum_field;
+                non_void_field_count += 1;
+            }
+        }
+        break :Tags .{
+            MaybeEnum(
+                void_max_value,
+                void_fields[0..void_field_count],
+            ),
+            MaybeEnum(
+                non_void_max_value,
+                non_void_fields[0..non_void_field_count],
+            ),
+        };
+    };
 
     var arity: c_int = 0;
     var type_tag: c_int = 0;
@@ -398,47 +454,47 @@ fn parse_union(self: Decoder, comptime T: type) Error!T {
         error.could_not_get_type,
         ei.ei_get_type(self.buf.buff, self.index, &type_tag, &_v),
     );
-    if (type_tag == ei.ERL_ATOM_EXT) {
-        switch (try self.parse_enum(Tag)) {
-            inline else => |tag| {
-                // TODO: eliminate this loop
-                inline for (fields) |field| {
-                    if (field.type == void and comptime std.mem.eql(
-                        u8,
-                        field.name,
-                        @tagName(tag),
-                    )) {
-                        return tag;
-                    }
-                }
-                return error.invalid_union_tag;
-            },
-        }
-    } else {
-        try erl.validate(
-            error.decoding_tuple,
-            ei.ei_decode_tuple_header(self.buf.buff, self.index, &arity),
-        );
-        if (arity != 2) {
-            // TODO: https://github.com/dont-rely-on-nulls/zerl/issues/7
-            return error.wrong_arity_for_tuple;
-        }
-        switch (try self.parse_enum(Tag)) {
-            inline else => |tag| {
-                inline for (fields) |field| {
-                    if (field.type != void and comptime std.mem.eql(
-                        u8,
-                        field.name,
-                        @tagName(tag),
-                    )) {
-                        const tuple_value = try self.parse(field.type);
-                        return @unionInit(T, field.name, tuple_value);
-                    }
-                } else return error.failed_to_receive_payload;
-            },
-        }
+    switch (type_tag) {
+        ei.ERL_ATOM_EXT => {
+            if (Atom == void) return error.could_not_decode_enum;
+
+            const atom: Tag = @enumFromInt(@intFromEnum(
+                try self.parse_enum(Atom),
+            ));
+            return switch (atom) {
+                inline else => |tag| if (@FieldType(T, @tagName(tag)) == void)
+                    tag
+                else
+                    unreachable,
+            };
+        },
+        ei.ERL_SMALL_TUPLE_EXT, ei.ERL_LARGE_TUPLE_EXT => {
+            if (Tuple_Tag == void) return error.could_not_decode_enum;
+
+            try erl.validate(
+                error.decoding_tuple,
+                ei.ei_decode_tuple_header(self.buf.buff, self.index, &arity),
+            );
+            if (arity != 2) {
+                // TODO: https://github.com/dont-rely-on-nulls/zerl/issues/7
+                return error.wrong_arity_for_tuple;
+            }
+            const tuple_tag: Tag = @enumFromInt(@intFromEnum(
+                try self.parse_enum(Tuple_Tag),
+            ));
+            switch (tuple_tag) {
+                inline else => |tag| {
+                    const Payload = @FieldType(T, @tagName(tag));
+                    if (Payload == void) unreachable;
+
+                    const tuple_value = try self.parse(Payload);
+                    return @unionInit(T, @tagName(tag), tuple_value);
+                },
+            }
+        },
+        else => return error.not_a_union,
     }
-    return error.unknown_tuple_tag;
+    comptime unreachable;
 }
 
 test parse_union {
@@ -451,14 +507,19 @@ test parse_union {
     const circle: Shape = .{ .circle = 4 };
     const square: Shape = .{ .square = 4 };
 
+    const Animal = union(enum) {
+        species: enum { cat, dog },
+    };
+
+    const catdog: union(enum) {
+        species: enum { catdog },
+    } = .{ .species = .catdog };
+
     var buf: ei.ei_x_buff = undefined;
     try erl.validate(error.create_new_decode_buff, ei.ei_x_new(&buf));
     defer _ = ei.ei_x_free(&buf);
 
     var index: c_int = 0;
-    try erl.encoder.write_any(&buf, circle);
-    try erl.encoder.write_any(&buf, square);
-    try erl.encoder.write_any(&buf, Shape.point);
 
     const decoder: Decoder = .{
         .buf = &buf,
@@ -466,9 +527,20 @@ test parse_union {
         .allocator = testing.failing_allocator,
     };
 
+    try erl.encoder.write_any(&buf, circle);
     try testing.expectEqual(circle, decoder.parse_union(Shape));
+
+    try erl.encoder.write_any(&buf, square);
     try testing.expectEqual(square, decoder.parse_union(Shape));
+
+    try erl.encoder.write_any(&buf, Shape.point);
     try testing.expectEqual(Shape.point, decoder.parse_union(Shape));
+
+    try erl.encoder.write_any(&buf, .not_a_shape);
+    try testing.expectEqual(error.could_not_decode_enum, decoder.parse_union(Shape));
+
+    try erl.encoder.write_any(&buf, catdog);
+    try testing.expectEqual(error.could_not_decode_enum, decoder.parse_union(Animal));
 }
 
 fn parse_pointer(self: Decoder, comptime T: type) Error!T {

--- a/src/Decoder.zig
+++ b/src/Decoder.zig
@@ -564,6 +564,15 @@ test parse_union {
         .allocator = testing.failing_allocator,
     };
 
+    try erl.encoder.write_any(&buf, circle);
+    try testing.expectEqual(circle, decoder.parse_union(Shape));
+
+    try erl.encoder.write_any(&buf, square);
+    try testing.expectEqual(square, decoder.parse_union(Shape));
+
+    try erl.encoder.write_any(&buf, Shape.point);
+    try testing.expectEqual(Shape.point, decoder.parse_union(Shape));
+
     try erl.encoder.write_any(&buf, .not_a_shape);
     try testing.expectEqual(error.could_not_decode_enum, decoder.parse_union(Shape));
     try erl.validate(error.skip_term, ei.ei_skip_term(buf.buff, &index));
@@ -602,15 +611,6 @@ test parse_union {
 
     try erl.encoder.write_any(&buf, tuple);
     try testing.expectEqual(flat_tuple, decoder.parse_tuple(Flat_Point));
-
-    try erl.encoder.write_any(&buf, circle);
-    try testing.expectEqual(circle, decoder.parse_union(Shape));
-
-    try erl.encoder.write_any(&buf, square);
-    try testing.expectEqual(square, decoder.parse_union(Shape));
-
-    try erl.encoder.write_any(&buf, Shape.point);
-    try testing.expectEqual(Shape.point, decoder.parse_union(Shape));
 }
 
 fn parse_pointer(self: Decoder, comptime T: type) Error!T {

--- a/src/encoder.zig
+++ b/src/encoder.zig
@@ -4,6 +4,8 @@ const erl = @import("erlang.zig");
 const ei = erl.ei;
 const assert = std.debug.assert;
 
+const union_case = @import("Decoder.zig").union_case;
+
 pub const Error = error{
     could_not_encode_pid,
     could_not_encode_binary,
@@ -52,13 +54,37 @@ fn write_pointer(buf: *ei.ei_x_buff, data: anytype) Error!void {
                 ),
                 .@"union" => |union_info| switch (@as(union_info.tag_type.?, data.*)) {
                     inline else => |tag| {
-                        inline for (union_info.fields) |field| {
-                            if (comptime std.mem.eql(
-                                u8,
-                                field.name,
-                                @tagName(tag),
-                            )) {
-                                const send_tuple: bool = field.type != void;
+                        const Field = @FieldType(Child, @tagName(tag));
+
+                        switch (union_case(Field)) {
+                            .array => {
+                                const payload = &@field(data, @tagName(tag));
+                                try erl.validate(
+                                    error.could_not_encode_tuple,
+                                    ei.ei_x_encode_tuple_header(buf, payload.len + 1),
+                                );
+                                try write_any(buf, tag);
+                                for (payload) |*elem| {
+                                    try write_any(buf, elem);
+                                }
+                            },
+                            .tuple => {
+                                const payload = &@field(data, @tagName(tag));
+                                const payload_len =
+                                    @typeInfo(Field).@"struct".fields.len;
+
+                                try erl.validate(
+                                    error.could_not_encode_tuple,
+                                    ei.ei_x_encode_tuple_header(buf, payload_len + 1),
+                                );
+                                try write_any(buf, tag);
+                                inline for (payload) |*elem| {
+                                    try write_any(buf, elem);
+                                }
+                            },
+                            .other => {
+                                const payload = @field(data, @tagName(tag));
+                                const send_tuple: bool = Field != void;
                                 if (send_tuple) {
                                     try erl.validate(
                                         error.could_not_encode_tuple,
@@ -66,8 +92,8 @@ fn write_pointer(buf: *ei.ei_x_buff, data: anytype) Error!void {
                                     );
                                 }
                                 try write_any(buf, tag);
-                                if (send_tuple) try write_any(buf, @field(data, @tagName(tag)));
-                            }
+                                if (send_tuple) try write_any(buf, payload);
+                            },
                         }
                     },
                 },


### PR DESCRIPTION
- Remove inline for loops.
- Be strict about only reading atoms when the union payload is void.
- Generally improve static guarantees.
- Close #7.